### PR TITLE
fix: v1.1.7 - Update User-Agent version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🎯 Cursor Update v1.1.6
+# 🎯 Cursor Update v1.1.7
 
 > **Unofficial Linux Installer & Version Manager for Cursor IDE**
 

--- a/cursor-update.sh
+++ b/cursor-update.sh
@@ -1095,7 +1095,7 @@ class CursorInstaller:
         """Initialize the installer with session and directories."""
         self.session = requests.Session()
         self.session.headers.update({
-            'User-Agent': 'Cursor-Update/1.1.2 (Linux)'
+            'User-Agent': 'Cursor-Update/1.1.7 (Linux)'
         })
         
         # Create directories

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "cursor-update",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "description": "Unofficial Linux Installer & Version Manager for Cursor IDE",
   "main": "cursor-update.sh",
   "scripts": {
     "test": "shellcheck cursor-update.sh",
     "install": "./cursor-update.sh",
     "update": "./cursor-update.sh",
-    "version": "echo v1.1.5"
+    "version": "echo v1.1.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🐛 Fix User-Agent Version

This PR fixes the User-Agent header in the script to reflect the correct version 1.1.7.

### 🔧 Changes
- **User-Agent**: Updated from `Cursor-Update/1.1.2 (Linux)` to `Cursor-Update/1.1.7 (Linux)`

### 📋 Context  
Found during version audit - the User-Agent header was still referencing the old version 1.1.2 instead of the current 1.1.7.